### PR TITLE
External function verification fix

### DIFF
--- a/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/BaseCodeUnit.xtend
+++ b/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/BaseCodeUnit.xtend
@@ -20,7 +20,11 @@ class BaseCodeUnit {
 	def generate(CodeUnit unit) '''
 		«unit.commonIncludes»
 		
-		«unit.externalFunctionInclude»
+		«IF isVerification(unit)»
+			«unit.externalFunctionIncludeDeclarationsOnly»
+		«ELSE»
+			«unit.externalFunctionInclude»
+		«ENDIF»
 		
 		«unit.commonMacroDefs»
 		
@@ -67,6 +71,19 @@ class BaseCodeUnit {
 		#include <float.h>
 	'''
 	
+	def isVerification(CodeUnit unit) {
+		unit.system.name.endsWith("_verify")
+	}
+
+	def externalFunctionIncludeDeclarationsOnly(CodeUnit unit) {
+		val baseUnit = new BaseCompilationUnit
+		if (unit.compilationUnit.program.externalFunctionDeclarations.size > 0) {
+			baseUnit.externalFunctionHeader(unit.compilationUnit.program)
+		} else {
+			''''''
+		}
+	}
+
 	def externalFunctionInclude(CodeUnit unit) {
 		if (unit.compilationUnit.program.externalFunctionDeclarations.size > 0) {
 			'''#include "«EXTERNAL_FUNCTION_HEADER_NAME»"'''	

--- a/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/BaseCompilationUnit.xtend
+++ b/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/BaseCompilationUnit.xtend
@@ -16,7 +16,7 @@ class BaseCompilationUnit {
 	
 	def String externalFunctionHeader(Program p) {
 		if (p.externalFunctionDeclarations.size > 0) {
-			"//External Functions\n" + p.externalFunctionDeclarations.join("\n", [ex|ex.externalFunctionDeclaration])
+			"//External Functions\n" + p.externalFunctionDeclarations.join("\n", [ex|ex.externalFunctionDeclaration + ";"])
 		}
 	}
 

--- a/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/impl/ProgramImpl.java
+++ b/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/impl/ProgramImpl.java
@@ -319,7 +319,7 @@ public class ProgramImpl extends EObjectImpl implements Program {
 		for (ExternalFunctionDeclaration extFunc : this.getExternalFunctionDeclarations()) {
 			ExternalFunctionDeclaration extFuncCopy = PolyhedralIRFactory.eINSTANCE.createExternalFunctionDeclaration();
 			extFuncCopy.setName(extFunc.getName());
-			extFuncCopy.setOutput(EcoreUtil.copy(extFuncCopy.getOutput()));
+			extFuncCopy.setOutput(EcoreUtil.copy(extFunc.getOutput()));
 			for (Type t : extFunc.getInputs())
 				extFuncCopy.getInputs().add(EcoreUtil.copy(t));
 			copy.getExternalFunctionDeclarations().add(extFuncCopy);


### PR DESCRIPTION
Fixes issue #1. When external functions are used, the code generator creates an associated header file (called `external_functions.h`. The user is subsequently supposed to define these functions in that header file. See here, for example:  
https://www.cs.colostate.edu/AlphaZ/wiki/doku.php?id=tutorial_external_function

However, when `generateVerificationCode` is called in the presence of external functions, the verification code also includes this same header (and subsequently the same definitions), and throws errors like this when trying to make:
```
$ make verify
cc bug.c -o bug.o -O3  -std=c99  -I/usr/include/malloc/ -lm -c
clang: warning: -lm: 'linker' input unused [-Wunused-command-line-argument]
cc bug_verify.c -o bug_verify.o -O3  -std=c99  -I/usr/include/malloc/ -lm -c
clang: warning: -lm: 'linker' input unused [-Wunused-command-line-argument]
cc bug-wrapper.c -o bug.verify bug.o  bug_verify.o -O3  -std=c99  -I/usr/include/malloc/ -lm -DVERIFY
duplicate symbol '_userfunc' in:
    bug.o
    bug_verify.o
ld: 1 duplicate symbol for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [verify] Error 1
```

Now, the verification codegen only generates the external function declarations in the `***_verify.c` file.