### PR TITLE
Add generated java files for verification fix

### DIFF
--- a/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/BaseCodeUnit.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/BaseCodeUnit.java
@@ -7,9 +7,6 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
-import org.polymodel.polyhedralIR.codegen.xtend2.BaseFunction;
-import org.polymodel.polyhedralIR.codegen.xtend2.BaseMemoryAccess;
-import org.polymodel.polyhedralIR.codegen.xtend2.Utility;
 import org.polymodel.polyhedralIR.polyIRCG.AbstractVariable;
 import org.polymodel.polyhedralIR.polyIRCG.CodeUnit;
 import org.polymodel.polyhedralIR.polyIRCG.CodeUnitHeader;
@@ -36,9 +33,18 @@ public class BaseCodeUnit {
     _builder.append(_commonIncludes);
     _builder.newLineIfNotEmpty();
     _builder.newLine();
-    CharSequence _externalFunctionInclude = this.externalFunctionInclude(unit);
-    _builder.append(_externalFunctionInclude);
-    _builder.newLineIfNotEmpty();
+    {
+      boolean _isVerification = this.isVerification(unit);
+      if (_isVerification) {
+        CharSequence _externalFunctionIncludeDeclarationsOnly = this.externalFunctionIncludeDeclarationsOnly(unit);
+        _builder.append(_externalFunctionIncludeDeclarationsOnly);
+        _builder.newLineIfNotEmpty();
+      } else {
+        CharSequence _externalFunctionInclude = this.externalFunctionInclude(unit);
+        _builder.append(_externalFunctionInclude);
+        _builder.newLineIfNotEmpty();
+      }
+    }
     _builder.newLine();
     CharSequence _commonMacroDefs = this.commonMacroDefs(unit);
     _builder.append(_commonMacroDefs);
@@ -133,6 +139,28 @@ public class BaseCodeUnit {
     _builder.append("#include <float.h>");
     _builder.newLine();
     return _builder;
+  }
+  
+  public boolean isVerification(final CodeUnit unit) {
+    return unit.getSystem().getName().endsWith("_verify");
+  }
+  
+  public CharSequence externalFunctionIncludeDeclarationsOnly(final CodeUnit unit) {
+    CharSequence _xblockexpression = null;
+    {
+      final BaseCompilationUnit baseUnit = new BaseCompilationUnit();
+      CharSequence _xifexpression = null;
+      int _size = unit.getCompilationUnit().getProgram().getExternalFunctionDeclarations().size();
+      boolean _greaterThan = (_size > 0);
+      if (_greaterThan) {
+        _xifexpression = baseUnit.externalFunctionHeader(unit.getCompilationUnit().getProgram());
+      } else {
+        StringConcatenation _builder = new StringConcatenation();
+        _xifexpression = _builder;
+      }
+      _xblockexpression = _xifexpression;
+    }
+    return _xblockexpression;
   }
   
   public CharSequence externalFunctionInclude(final CodeUnit unit) {

--- a/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/BaseCompilationUnit.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/BaseCompilationUnit.java
@@ -11,7 +11,6 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.polymodel.polyhedralIR.ExternalFunctionDeclaration;
 import org.polymodel.polyhedralIR.Program;
 import org.polymodel.polyhedralIR.Type;
-import org.polymodel.polyhedralIR.codegen.xtend2.BaseCodeUnit;
 import org.polymodel.polyhedralIR.polyIRCG.CodeUnit;
 import org.polymodel.polyhedralIR.polyIRCG.CompilationUnit;
 import org.polymodel.polyhedralIR.polyIRCG.generator.C.CodeGenConstantsForC;
@@ -28,7 +27,8 @@ public class BaseCompilationUnit {
     boolean _greaterThan = (_size > 0);
     if (_greaterThan) {
       final Function1<ExternalFunctionDeclaration, CharSequence> _function = (ExternalFunctionDeclaration ex) -> {
-        return this.externalFunctionDeclaration(ex);
+        CharSequence _externalFunctionDeclaration = this.externalFunctionDeclaration(ex);
+        return (_externalFunctionDeclaration + ";");
       };
       String _join = IterableExtensions.<ExternalFunctionDeclaration>join(p.getExternalFunctionDeclarations(), "\n", _function);
       _xifexpression = ("//External Functions\n" + _join);


### PR DESCRIPTION
In PR #3, I made changes to some xtend files without also committing the changes to their corresponding generated java files. So the new version of the plugin built/published did not include the changes reflected in the xtend files. Apparently, building the AlphaZ plugin from the command line with `mvn package` does not compile the xtend files. This must be done in Eclipse.

Long term, perhaps we can find a better way to avoid this problem. Either by figuring out how to run the xtend compilation process with maven, and/or adding checks to the PR process here. 

Regardless, these changes just include the corresponding java files that I should have included in PR #3.