### PR TITLE
Add codesigning for mac bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,9 @@ name: build
 on:
   push:
     branches:
-#      - main
-      - dev-mac-bundle
-#  schedule:
-#    - cron:  '0 9 * * *'  # 3am MT, 9am UTC
+      - main
+  schedule:
+    - cron:  '0 9 * * *'  # 3am MT, 9am UTC
 
 jobs:
   clear-cache:
@@ -40,67 +39,66 @@ jobs:
             console.log("Clear completed")
 
 
-#  build-plugin:
-#    needs: clear-cache
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#
-#    - name: Set up java 11
-#      uses: actions/setup-java@v1
-#      with:
-#        java-version: 11
-#
-#    - name: Cache alphaz plugin
-#      id: cache-plugin
-#      uses: actions/cache@v3
-#      with:
-#        path: ./releng/alphaz.update/target/repository
-#        key: cache-plugin
-#
-#    - name: build alphaz
-#      run: mvn clean package
+  build-plugin:
+    needs: clear-cache
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up java 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Cache alphaz plugin
+      id: cache-plugin
+      uses: actions/cache@v3
+      with:
+        path: ./releng/alphaz.update/target/repository
+        key: cache-plugin
+
+    - name: build alphaz
+      run: mvn clean package
 
 
-#  build-bundle-linux-x86:
-#    needs: build-plugin
-#
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#
-#    - name: Set up java 11
-#      uses: actions/setup-java@v1
-#      with:
-#        java-version: 11
-#
-#    - name: Cache alphaz plugin
-#      id: cache-plugin
-#      uses: actions/cache@v3
-#      with:
-#        path: ./releng/alphaz.update/target/repository
-#        key: cache-plugin
-#
-#    - name: Cache eclipse bundle linux-x86
-#      id: cache-eclipse-linux-x86
-#      uses: actions/cache@v3
-#      with:
-#        path: eclipse-bundle-linux-x86
-#        key: cache-eclipse-linux-x86
-#
-#    - name: Set SHORT_SHA 
-#      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-#
-#    - name: Build linux x86 bundle
-#      run: ./scripts/make-bundle.sh linux-x86
+  build-bundle-linux-x86:
+    needs: build-plugin
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up java 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Cache alphaz plugin
+      id: cache-plugin
+      uses: actions/cache@v3
+      with:
+        path: ./releng/alphaz.update/target/repository
+        key: cache-plugin
+
+    - name: Cache eclipse bundle linux-x86
+      id: cache-eclipse-linux-x86
+      uses: actions/cache@v3
+      with:
+        path: eclipse-bundle-linux-x86
+        key: cache-eclipse-linux-x86
+
+    - name: Set SHORT_SHA 
+      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+
+    - name: Build linux x86 bundle
+      run: ./scripts/make-bundle.sh linux-x86
 
 
   build-bundle-mac-x86:
-#    needs: build-plugin
-    needs: clear-cache
+    needs: build-plugin
 
     runs-on: macos-latest
 
@@ -120,12 +118,12 @@ jobs:
         path: eclipse-download-mac-x86
         key: eclipse-download-mac-x86
 
-#    - name: Cache alphaz plugin
-#      id: cache-plugin
-#      uses: actions/cache@v3
-#      with:
-#        path: ./releng/alphaz.update/target/repository
-#        key: cache-plugin
+    - name: Cache alphaz plugin
+      id: cache-plugin
+      uses: actions/cache@v3
+      with:
+        path: ./releng/alphaz.update/target/repository
+        key: cache-plugin
 
     - name: Cache eclipse bundle mac-x86
       id: cache-eclipse-mac-x86
@@ -148,84 +146,79 @@ jobs:
         security default-keychain -s build.keychain
         security unlock-keychain -p $KEYCHAIN_PASSWORD build.keychain
         security import certificate.p12 -k build.keychain -P $P12_PASSWORD -T /usr/bin/codesign
-        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PASSWORD build.keychain
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PASSWORD build.keychain > /dev/null
         ./scripts/make-bundle.sh mac-x86
 
-#    - name: (debug) upload signed bundle
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: mac-bundle
-#        path: eclipse-bundle-mac-x86/eclipse-alphaz-mac-x86.dmg
 
-#  deploy:
-#    needs: 
-#    - build-plugin
-#    - build-bundle-mac-x86
-#    - build-bundle-linux-x86
-#
-#    permissions:
-#      pages: write      # to deploy to Pages
-#      id-token: write   # to verify the deployment originates from an appropriate source
-#
-#    environment:
-#      name: github-pages
-#      url: ${{ steps.deployment.outputs.page_url }}
-#      
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#
-#    - name: Cache alphaz plugin
-#      id: cache-plugin
-#      uses: actions/cache@v3
-#      with:
-#        path: ./releng/alphaz.update/target/repository
-#        key: cache-plugin
-#
-#    - name: Cache eclipse bundle linux-x86
-#      id: cache-eclipse-linux-x86
-#      uses: actions/cache@v3
-#      with:
-#        path: eclipse-bundle-linux-x86
-#        key: cache-eclipse-linux-x86
-#
-#    - name: Cache eclipse bundle mac-x86
-#      id: cache-eclipse-mac-x86
-#      uses: actions/cache@v3
-#      with:
-#        path: eclipse-bundle-mac-x86
-#        key: cache-eclipse-mac-x86
-#
-#    - name: Set SHORT_SHA 
-#      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-#
-#    - name: Make downloads directory
-#      run: mkdir -p ./releng/alphaz.update/target/repository/downloads
-#
-#    - name: Move linux-x86 to staging
-#      run: mv eclipse-bundle-linux-x86/eclipse-alphaz-linux-x86.tar.gz ./releng/alphaz.update/target/repository/downloads/
-#
-#    - name: Move mac-x86 to staging
-#      run: mv eclipse-bundle-mac-x86/eclipse-alphaz-mac-x86.dmg ./releng/alphaz.update/target/repository/downloads/
-#
-#    - name: make update-site readme
-#      run: ./scripts/make-update-site-readme.sh
-# 
-#    - name: build update-site
-#      uses: actions/jekyll-build-pages@v1
-#      with:
-#        source: "./releng/alphaz.update/target/repository"
-#        destination: "./update-site"
-#
-#    - name: Upload artifact
-#      uses: actions/upload-pages-artifact@v1
-#      with:
-#        path: "./update-site"
-#
-#    - name: deploy update-site
-#      id: deployment
-#      uses: actions/deploy-pages@v2 # or the latest "vX.X.X" version tag for this action
-#
-#
-#
+  deploy:
+    needs: 
+    - build-plugin
+    - build-bundle-mac-x86
+    - build-bundle-linux-x86
+
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+      
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache alphaz plugin
+      id: cache-plugin
+      uses: actions/cache@v3
+      with:
+        path: ./releng/alphaz.update/target/repository
+        key: cache-plugin
+
+    - name: Cache eclipse bundle linux-x86
+      id: cache-eclipse-linux-x86
+      uses: actions/cache@v3
+      with:
+        path: eclipse-bundle-linux-x86
+        key: cache-eclipse-linux-x86
+
+    - name: Cache eclipse bundle mac-x86
+      id: cache-eclipse-mac-x86
+      uses: actions/cache@v3
+      with:
+        path: eclipse-bundle-mac-x86
+        key: cache-eclipse-mac-x86
+
+    - name: Set SHORT_SHA 
+      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+
+    - name: Make downloads directory
+      run: mkdir -p ./releng/alphaz.update/target/repository/downloads
+
+    - name: Move linux-x86 to staging
+      run: mv eclipse-bundle-linux-x86/eclipse-alphaz-linux-x86.tar.gz ./releng/alphaz.update/target/repository/downloads/
+
+    - name: Move mac-x86 to staging
+      run: mv eclipse-bundle-mac-x86/eclipse-alphaz-mac-x86.dmg ./releng/alphaz.update/target/repository/downloads/
+
+    - name: make update-site readme
+      run: ./scripts/make-update-site-readme.sh
+ 
+    - name: build update-site
+      uses: actions/jekyll-build-pages@v1
+      with:
+        source: "./releng/alphaz.update/target/repository"
+        destination: "./update-site"
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: "./update-site"
+
+    - name: deploy update-site
+      id: deployment
+      uses: actions/deploy-pages@v2 # or the latest "vX.X.X" version tag for this action
+
+
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,10 @@ name: build
 on:
   push:
     branches:
-      - main
-  schedule:
-    - cron:  '0 9 * * *'  # 3am MT, 9am UTC
+#      - main
+      - dev-mac-bundle
+#  schedule:
+#    - cron:  '0 9 * * *'  # 3am MT, 9am UTC
 
 jobs:
   clear-cache:
@@ -20,7 +21,15 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             })
+            const keys_to_clear = [
+              'cache-plugin',
+              'cache-eclipse-linux-x86',
+              'cache-eclipse-mac-x86'
+            ]
             for (const cache of caches.data.actions_caches) {
+              if (!keys_to_clear.includes(cache.key)) {
+                continue
+              }
               console.log(cache)
               github.rest.actions.deleteActionsCacheById({
                 owner: context.repo.owner,
@@ -31,66 +40,67 @@ jobs:
             console.log("Clear completed")
 
 
-  build-plugin:
-    needs: clear-cache
+#  build-plugin:
+#    needs: clear-cache
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#    - uses: actions/checkout@v2
+#
+#    - name: Set up java 11
+#      uses: actions/setup-java@v1
+#      with:
+#        java-version: 11
+#
+#    - name: Cache alphaz plugin
+#      id: cache-plugin
+#      uses: actions/cache@v3
+#      with:
+#        path: ./releng/alphaz.update/target/repository
+#        key: cache-plugin
+#
+#    - name: build alphaz
+#      run: mvn clean package
 
-    runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up java 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-
-    - name: Cache alphaz plugin
-      id: cache-plugin
-      uses: actions/cache@v3
-      with:
-        path: ./releng/alphaz.update/target/repository
-        key: cache-plugin
-
-    - name: build alphaz
-      run: mvn clean package
-
-
-  build-bundle-linux-x86:
-    needs: build-plugin
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up java 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-
-    - name: Cache alphaz plugin
-      id: cache-plugin
-      uses: actions/cache@v3
-      with:
-        path: ./releng/alphaz.update/target/repository
-        key: cache-plugin
-
-    - name: Cache eclipse bundle linux-x86
-      id: cache-eclipse-linux-x86
-      uses: actions/cache@v3
-      with:
-        path: eclipse-bundle-linux-x86
-        key: cache-eclipse-linux-x86
-
-    - name: Set SHORT_SHA 
-      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-
-    - name: Build linux x86 bundle
-      run: ./scripts/make-bundle.sh linux-x86
+#  build-bundle-linux-x86:
+#    needs: build-plugin
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#    - uses: actions/checkout@v2
+#
+#    - name: Set up java 11
+#      uses: actions/setup-java@v1
+#      with:
+#        java-version: 11
+#
+#    - name: Cache alphaz plugin
+#      id: cache-plugin
+#      uses: actions/cache@v3
+#      with:
+#        path: ./releng/alphaz.update/target/repository
+#        key: cache-plugin
+#
+#    - name: Cache eclipse bundle linux-x86
+#      id: cache-eclipse-linux-x86
+#      uses: actions/cache@v3
+#      with:
+#        path: eclipse-bundle-linux-x86
+#        key: cache-eclipse-linux-x86
+#
+#    - name: Set SHORT_SHA 
+#      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+#
+#    - name: Build linux x86 bundle
+#      run: ./scripts/make-bundle.sh linux-x86
 
 
   build-bundle-mac-x86:
-    needs: build-plugin
+#    needs: build-plugin
+    needs: clear-cache
 
     runs-on: macos-latest
 
@@ -103,12 +113,19 @@ jobs:
         distribution: 'zulu'
         java-version: '11'
 
-    - name: Cache alphaz plugin
-      id: cache-plugin
+    - name: Cache eclipse download
+      id: cache-eclipse-download-mac-x86
       uses: actions/cache@v3
       with:
-        path: ./releng/alphaz.update/target/repository
-        key: cache-plugin
+        path: eclipse-download-mac-x86
+        key: eclipse-download-mac-x86
+
+#    - name: Cache alphaz plugin
+#      id: cache-plugin
+#      uses: actions/cache@v3
+#      with:
+#        path: ./releng/alphaz.update/target/repository
+#        key: cache-plugin
 
     - name: Cache eclipse bundle mac-x86
       id: cache-eclipse-mac-x86
@@ -121,78 +138,94 @@ jobs:
       run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
 
     - name: Build mac x86 bundle
-      run: ./scripts/make-bundle.sh mac-x86
+      env: 
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      run: |
+        echo $BUILD_CERTIFICATE_BASE64 | base64 --decode > certificate.p12
+        security create-keychain -p $KEYCHAIN_PASSWORD build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p $KEYCHAIN_PASSWORD build.keychain
+        security import certificate.p12 -k build.keychain -P $P12_PASSWORD -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PASSWORD build.keychain
+        ./scripts/make-bundle.sh mac-x86
 
+#    - name: (debug) upload signed bundle
+#      uses: actions/upload-artifact@v3
+#      with:
+#        name: mac-bundle
+#        path: eclipse-bundle-mac-x86/eclipse-alphaz-mac-x86.dmg
 
-  deploy:
-    needs: 
-    - build-plugin
-    - build-bundle-mac-x86
-    - build-bundle-linux-x86
-
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-      
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Cache alphaz plugin
-      id: cache-plugin
-      uses: actions/cache@v3
-      with:
-        path: ./releng/alphaz.update/target/repository
-        key: cache-plugin
-
-    - name: Cache eclipse bundle linux-x86
-      id: cache-eclipse-linux-x86
-      uses: actions/cache@v3
-      with:
-        path: eclipse-bundle-linux-x86
-        key: cache-eclipse-linux-x86
-
-    - name: Cache eclipse bundle mac-x86
-      id: cache-eclipse-mac-x86
-      uses: actions/cache@v3
-      with:
-        path: eclipse-bundle-mac-x86
-        key: cache-eclipse-mac-x86
-
-    - name: Set SHORT_SHA 
-      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-
-    - name: Make downloads directory
-      run: mkdir -p ./releng/alphaz.update/target/repository/downloads
-
-    - name: Move linux-x86 to staging
-      run: mv eclipse-bundle-linux-x86/eclipse-alphaz-linux-x86.tar.gz ./releng/alphaz.update/target/repository/downloads/
-
-    - name: Move mac-x86 to staging
-      run: mv eclipse-bundle-mac-x86/eclipse-alphaz-mac-x86.dmg ./releng/alphaz.update/target/repository/downloads/
-
-    - name: make update-site readme
-      run: ./scripts/make-update-site-readme.sh
- 
-    - name: build update-site
-      uses: actions/jekyll-build-pages@v1
-      with:
-        source: "./releng/alphaz.update/target/repository"
-        destination: "./update-site"
-
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
-      with:
-        path: "./update-site"
-
-    - name: deploy update-site
-      id: deployment
-      uses: actions/deploy-pages@v2 # or the latest "vX.X.X" version tag for this action
-
-
-
+#  deploy:
+#    needs: 
+#    - build-plugin
+#    - build-bundle-mac-x86
+#    - build-bundle-linux-x86
+#
+#    permissions:
+#      pages: write      # to deploy to Pages
+#      id-token: write   # to verify the deployment originates from an appropriate source
+#
+#    environment:
+#      name: github-pages
+#      url: ${{ steps.deployment.outputs.page_url }}
+#      
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#    - uses: actions/checkout@v2
+#
+#    - name: Cache alphaz plugin
+#      id: cache-plugin
+#      uses: actions/cache@v3
+#      with:
+#        path: ./releng/alphaz.update/target/repository
+#        key: cache-plugin
+#
+#    - name: Cache eclipse bundle linux-x86
+#      id: cache-eclipse-linux-x86
+#      uses: actions/cache@v3
+#      with:
+#        path: eclipse-bundle-linux-x86
+#        key: cache-eclipse-linux-x86
+#
+#    - name: Cache eclipse bundle mac-x86
+#      id: cache-eclipse-mac-x86
+#      uses: actions/cache@v3
+#      with:
+#        path: eclipse-bundle-mac-x86
+#        key: cache-eclipse-mac-x86
+#
+#    - name: Set SHORT_SHA 
+#      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+#
+#    - name: Make downloads directory
+#      run: mkdir -p ./releng/alphaz.update/target/repository/downloads
+#
+#    - name: Move linux-x86 to staging
+#      run: mv eclipse-bundle-linux-x86/eclipse-alphaz-linux-x86.tar.gz ./releng/alphaz.update/target/repository/downloads/
+#
+#    - name: Move mac-x86 to staging
+#      run: mv eclipse-bundle-mac-x86/eclipse-alphaz-mac-x86.dmg ./releng/alphaz.update/target/repository/downloads/
+#
+#    - name: make update-site readme
+#      run: ./scripts/make-update-site-readme.sh
+# 
+#    - name: build update-site
+#      uses: actions/jekyll-build-pages@v1
+#      with:
+#        source: "./releng/alphaz.update/target/repository"
+#        destination: "./update-site"
+#
+#    - name: Upload artifact
+#      uses: actions/upload-pages-artifact@v1
+#      with:
+#        path: "./update-site"
+#
+#    - name: deploy update-site
+#      id: deployment
+#      uses: actions/deploy-pages@v2 # or the latest "vX.X.X" version tag for this action
+#
+#
+#

--- a/scripts/make-bundle.sh
+++ b/scripts/make-bundle.sh
@@ -71,34 +71,32 @@ if [[ $OS == "mac" ]]; then
 
     eclipse_instance="./alphaz-bundle/Eclipse.app/Contents/MacOS/eclipse"
 
-#    # install GeCoS & Xtext plugins
-#    bash ./scripts/install-plugins.sh $eclipse_instance scripts/resources/required-plugins.p2f
-#    
-#    # install AlphaZ plugin
-#    if [[ -n "$IN_ACTION_RUNNER" ]]; then
-#        $eclipse_instance \
-#            -nosplash \
-#            -application org.eclipse.equinox.p2.director \
-#            -repository file:///Users/runner/work/AlphaZ/AlphaZ/releng/alphaz.update/target/repository \
-#            -installIU alphaz.feature.feature.group
-#    else
-#        bash ./scripts/install-plugins.sh $eclipse_instance scripts/resources/alphaz-plugins-master.p2f
-#    fi
-#    # create eclipse disk image file
-#    rm -f "eclipse-alphaz-$version.dmg"
-#    ln -s /Applications alphaz-bundle/Applications
-#    hdiutil create -fs HFS+ -srcfolder alphaz-bundle -volname "eclipse-alphaz-$version" "eclipse-alphaz-$version.dmg"
-
+    # install GeCoS & Xtext plugins
+    bash ./scripts/install-plugins.sh $eclipse_instance scripts/resources/required-plugins.p2f
+    
+    # install AlphaZ plugin
+    if [[ -n "$IN_ACTION_RUNNER" ]]; then
+        $eclipse_instance \
+            -nosplash \
+            -application org.eclipse.equinox.p2.director \
+            -repository file:///Users/runner/work/AlphaZ/AlphaZ/releng/alphaz.update/target/repository \
+            -installIU alphaz.feature.feature.group
+    else
+        bash ./scripts/install-plugins.sh $eclipse_instance scripts/resources/alphaz-plugins-master.p2f
+    fi
+    # create eclipse disk image file
+    rm -f "eclipse-alphaz-$version.dmg"
     # sign the disk image if in action runner
     if [[ -n "$IN_ACTION_RUNNER" ]]; then
         eclipse_app="./alphaz-bundle/Eclipse.app"
         signing_identity=`security find-identity -v -p codesigning | cut -d' ' -f 4`
-        echo "/usr/bin/codesign -s $signing_identity $eclipse_app -v"
         /usr/bin/codesign --force -s $signing_identity $eclipse_app -v
-
     fi
+    # add a symlink for the dmg and create the disk image
+    ln -s /Applications alphaz-bundle/Applications
+    hdiutil create -fs HFS+ -srcfolder alphaz-bundle -volname "eclipse-alphaz-$version" "eclipse-alphaz-$version.dmg"
 
 fi
 
-#mkdir -p eclipse-bundle-$version
-#mv eclipse-alphaz-$version.$suffix eclipse-bundle-$version/
+mkdir -p eclipse-bundle-$version
+mv eclipse-alphaz-$version.$suffix eclipse-bundle-$version/

--- a/scripts/make-bundle.sh
+++ b/scripts/make-bundle.sh
@@ -59,10 +59,11 @@ if [[ $OS == "linux" ]]; then
 fi
 
 if [[ $OS == "mac" ]]; then
-    if [[ ! -f eclipse.dmg ]]; then
-        wget -O eclipse.dmg $eclipse_url
+    mkdir -p eclipse-download-mac-x86
+    if [[ ! -f eclipse-download-mac-x86/eclipse.dmg ]]; then
+        wget -O eclipse-download-mac-x86/eclipse.dmg $eclipse_url
     fi
-    hdiutil attach -nobrowse -mountpoint eclipse-mnt eclipse.dmg 
+    hdiutil attach -nobrowse -mountpoint eclipse-mnt eclipse-download-mac-x86/eclipse.dmg 
     rm -rf alphaz-bundle/
     mkdir alphaz-bundle/
     cp -R eclipse-mnt/Eclipse.app alphaz-bundle/
@@ -70,25 +71,34 @@ if [[ $OS == "mac" ]]; then
 
     eclipse_instance="./alphaz-bundle/Eclipse.app/Contents/MacOS/eclipse"
 
-    # install GeCoS & Xtext plugins
-    bash ./scripts/install-plugins.sh $eclipse_instance scripts/resources/required-plugins.p2f
-    
-    # install AlphaZ plugin
+#    # install GeCoS & Xtext plugins
+#    bash ./scripts/install-plugins.sh $eclipse_instance scripts/resources/required-plugins.p2f
+#    
+#    # install AlphaZ plugin
+#    if [[ -n "$IN_ACTION_RUNNER" ]]; then
+#        $eclipse_instance \
+#            -nosplash \
+#            -application org.eclipse.equinox.p2.director \
+#            -repository file:///Users/runner/work/AlphaZ/AlphaZ/releng/alphaz.update/target/repository \
+#            -installIU alphaz.feature.feature.group
+#    else
+#        bash ./scripts/install-plugins.sh $eclipse_instance scripts/resources/alphaz-plugins-master.p2f
+#    fi
+#    # create eclipse disk image file
+#    rm -f "eclipse-alphaz-$version.dmg"
+#    ln -s /Applications alphaz-bundle/Applications
+#    hdiutil create -fs HFS+ -srcfolder alphaz-bundle -volname "eclipse-alphaz-$version" "eclipse-alphaz-$version.dmg"
+
+    # sign the disk image if in action runner
     if [[ -n "$IN_ACTION_RUNNER" ]]; then
-        $eclipse_instance \
-            -nosplash \
-            -application org.eclipse.equinox.p2.director \
-            -repository file:///Users/runner/work/AlphaZ/AlphaZ/releng/alphaz.update/target/repository \
-            -installIU alphaz.feature.feature.group
-    else
-        bash ./scripts/install-plugins.sh $eclipse_instance scripts/resources/alphaz-plugins-master.p2f
+        eclipse_app="./alphaz-bundle/Eclipse.app"
+        signing_identity=`security find-identity -v -p codesigning | cut -d' ' -f 4`
+        echo "/usr/bin/codesign -s $signing_identity $eclipse_app -v"
+        /usr/bin/codesign --force -s $signing_identity $eclipse_app -v
+
     fi
-    # create eclipse disk image file
-    rm -f "eclipse-alphaz-$version.dmg"
-    ln -s /Applications alphaz-bundle/Applications
-    xattr -cr ./alphaz-bundle/Eclipse.app # gecos/alphaz plugins are not "officially" signed
-    hdiutil create -fs HFS+ -srcfolder alphaz-bundle -volname "eclipse-alphaz-$version" "eclipse-alphaz-$version.dmg"
+
 fi
 
-mkdir -p eclipse-bundle-$version
-mv eclipse-alphaz-$version.$suffix eclipse-bundle-$version/
+#mkdir -p eclipse-bundle-$version
+#mv eclipse-alphaz-$version.$suffix eclipse-bundle-$version/


### PR DESCRIPTION
The workflow to build the Mac Eclipse bundle creates a disk image (dmg). However, the Gecos and AlphaZ components are unsigned so Mac OS will often quarantine the entire Eclipse.app bundle as corrupt/damaged.

This PR signs the Eclipse.app bundle. This is based on the documentation here:  
https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development

To make this work, I also needed to add the following repository-level secrets:
* `BUILD_CERTIFICATE_BASE64` - the base64 encoded string of the *.p12 certificate obtained from Apple's Xcode for my developer identity
* `P12_PASSWORD` - the password specified when exporting the above mentioned *.p12 certificate
* `KEYCHAIN_PASSWORD` - the password to be used in the runner (this can be anything)

as described in that^^ link. As far as I can tell, all codesignings performed on Mac OS must be tied to an individual Apple developer account. Long term, we should move this off of my individual one, but we would need to figure out how to manage that account.