### PR TITLE
reduction decomposition fix

### DIFF
--- a/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/transformation/reduction/ReductionDecomposition.java
+++ b/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/transformation/reduction/ReductionDecomposition.java
@@ -2,7 +2,9 @@ package org.polymodel.polyhedralIR.transformation.reduction;
 
 import org.polymodel.polyhedralIR.AffineFunction;
 import org.polymodel.polyhedralIR.expression.ReduceExpression;
+import org.polymodel.polyhedralIR.expression.RestrictExpression;
 import org.polymodel.polyhedralIR.factory.PolyhedralIRUserFactory;
+import org.polymodel.polyhedralIR.util.ContextDomainCalculator;
 
 import fr.irisa.cairn.tools.ecore.EcoreUpdater;
 
@@ -20,10 +22,17 @@ public class ReductionDecomposition {
 		//Check for equivalence of the projection functions
 		if (f1.compose(f2).equivalence(re.getProjection())) {
 			//Create new reductions
-			ReduceExpression newRed = PolyhedralIRUserFactory.eINSTANCE.createReduceExpression(re.getOP(), f1,
-					PolyhedralIRUserFactory.eINSTANCE.createReduceExpression(re.getOP(), f2, re.getExpr().copy()));
+			ReduceExpression inner = PolyhedralIRUserFactory.eINSTANCE.createReduceExpression(re.getOP(), f2, re.getExpr().copy());
+			ReduceExpression newRed = PolyhedralIRUserFactory.eINSTANCE.createReduceExpression(re.getOP(), f1, inner);
 			//Update all references to the original object
 			EcoreUpdater.update(re, newRed);
+
+			ContextDomainCalculator.computeContextDomain(newRed);
+			RestrictExpression restrictedInner = PolyhedralIRUserFactory.eINSTANCE.createRestrictExpression(
+					inner.getContextDomain(),
+					inner.copy()
+			);
+			EcoreUpdater.update(inner, restrictedInner);
 		} else {
 			throw new RuntimeException(f1 + " o " + f2 + " does not equal to the original projection function : " + re.getProjection());
 		}


### PR DESCRIPTION
Fixes issue #6, where the simplification in context step (i.e., isl gist) may produce an incorrect result.

Reduction decomposition takes the reduction,
```
reduce(op, f, E)
```
and rewrites it as,
```
reduce(op, f'', reduce(op, f', E))
```
given `f = f'' o f'`.

The example shown in issue #6 isn't really incorrect until it gets written to a file via `Show`. The "missing" `k<N-i`constraint is still present in that example because it's implicitly represented in the context domain of the inner reduction. Since, this constraint is in the context domain, simplification in context removes it (i.e., isl gist removes it).

The inner reduction is now restricted to its context domain, which is always legal to do. Now the rewrite is done like this,
```
reduce(op, f'', D : reduce(op, f', E))
```
where D is the context domain of the inner reduction.