### PR TITLE
Use gecos mirror while certificates are being updated

### DIFF
--- a/releng/alphaz.target/alphaz.target.target
+++ b/releng/alphaz.target/alphaz.target.target
@@ -4,27 +4,27 @@
 <!-- GeCoS -->
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.jnimapper.feature.feature.group" range="[1.2.0,2.0.0)"/>
-<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-jnimapper/artifacts/"/>
+<repository location="https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-jnimapper/artifacts/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.emf.feature.feature.group" range="[1.0.0,2.0.0)"/>
-<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-emf/artifacts/"/>
+<repository location="https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-emf/artifacts/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.framework.feature.feature.group" range="[1.4.0,2.0.0)"/>
-<repository location="https://gecos.gitlabpages.inria.fr/gecos-framework/artifacts/"/>
+<repository location="https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-framework/artifacts/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.tommapping.feature.feature.group" range="[1.0.1,2.0.0)"/>
-<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tommapping/artifacts/"/>
+<repository location="https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tommapping/artifacts/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.tomsdk.feature.feature.group" range="[2.10.6,3.0.0)"/>
-<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tomsdk/artifacts/"/>
+<repository location="https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tomsdk/artifacts/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.irisa.cairn.gecos.tools.graph.feature.feature.group" range="[1.0.1,2.0.0)"/>
-<repository location="https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-graph/artifacts/"/>
+<repository location="https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-graph/artifacts/"/>
 </location>
 
 <!-- Eclipse/Xtend/Xtext -->

--- a/scripts/resources/required-plugins.p2f
+++ b/scripts/resources/required-plugins.p2f
@@ -4,82 +4,82 @@
   <ius size='17'>
     <iu id='fr.irisa.cairn.gecos.tools.emf.feature.feature.group' name='GeCoS EMF Tools' version='1.0.1.202202021419'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-emf/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-emf/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.emf.feature.source.feature.group' name='GeCoS EMF Tools Developer Resources' version='1.0.1.202202021419'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-emf/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-emf/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.framework.feature.feature.group' name='GeCoS Framework' version='1.4.0.202202031020'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-framework/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-framework/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.framework.feature.source.feature.group' name='GeCoS Framework Developer Resources' version='1.4.0.202202031020'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-framework/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-framework/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.graph.feature.feature.group' name='GeCoS Graph Tools' version='1.0.1.202202031001'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-graph/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-graph/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.graph.feature.source.feature.group' name='GeCoS Graph Tools Developer Resources' version='1.0.1.202202031001'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-graph/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-graph/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.barvinok.feature.feature.group' name='GeCoS JNI Barvinok bindings' version='2.4.0.202202030940'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-isl/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-isl/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.barvinok.feature.source.feature.group' name='GeCoS JNI Barvinok bindings Developer Resources' version='2.4.0.202202030940'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-isl/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-isl/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.isl.feature.feature.group' name='GeCoS JNI ISL bindings' version='2.4.0.202202030940'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-isl/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-isl/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.isl.feature.source.feature.group' name='GeCoS JNI ISL bindings Developer Resources' version='2.4.0.202202030940'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-isl/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-isl/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.jnimapper.feature.feature.group' name='GeCoS JNI Mapper Tools' version='1.4.0.202202030956'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-jnimapper/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-jnimapper/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.jnimapper.feature.source.feature.group' name='GeCoS JNI Mapper Tools Developer Resources' version='1.4.0.202202030956'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-jnimapper/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-jnimapper/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.tommapping.feature.feature.group' name='GeCoS TOM Mapping Tools' version='1.0.1.202202021203'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tommapping/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tommapping/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.tommapping.feature.source.feature.group' name='GeCoS TOM Mapping Tools Developer Resources' version='1.0.1.202202021203'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tommapping/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tommapping/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.tomsdk.feature.feature.group' name='GeCoS TOM Tools' version='2.10.6.202202011652'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tomsdk/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tomsdk/artifacts/'/>
       </repositories>
     </iu>
     <iu id='fr.irisa.cairn.gecos.tools.tomsdk.feature.source.feature.group' name='GeCoS TOM Tools Developer Resources' version='2.10.6.202202011652'>
       <repositories size='1'>
-        <repository location='https://gecos.gitlabpages.inria.fr/gecos-tools/gecos-tools-tomsdk/artifacts/'/>
+        <repository location='https://www.cs.colostate.edu/AlphaZ/gecos-mirror/gecos-tools-tomsdk/artifacts/'/>
       </repositories>
     </iu>
     <iu id='org.eclipse.xtext.sdk.feature.group' name='Xtext Complete SDK' version='2.25.0.v20210301-1429'>


### PR DESCRIPTION
The GeCoS update site SSL certificate expired June 9 (yesterday), so our builds started failing.

Changing the repository locations to a temporary mirror that I set up on the CSU servers, while the certificates are being updated.