### PR TITLE
Verification fix and Makefile changes

### DIFF
--- a/bundles/edu.csu.melange.alphaz.commands.scripts.mde/src-gen/edu/csu/melange/alphaz/commands/scripts/GenerateMakefile.java
+++ b/bundles/edu.csu.melange.alphaz.commands.scripts.mde/src-gen/edu/csu/melange/alphaz/commands/scripts/GenerateMakefile.java
@@ -23,6 +23,26 @@ public class GenerateMakefile  {
 		}
 	}//function
 	
+	/**
+	Generates Makefile to compile generated code + wrapper.
+	**/
+	public GenerateMakefile(@IModuleArgumentName(name="program") Program program,
+@IModuleArgumentName(name="system") String system,
+@IModuleArgumentName(name="CodeGenOptions") CodeGenOptions CodeGenOptions,
+@IModuleArgumentName(name="outDir") String outDir,
+@IModuleArgumentName(name="withVerification") boolean withVerification) {
+	    try {
+		    alphaz.mde.CodeGen.generateMakefile(program,system,CodeGenOptions,outDir,withVerification);
+		} catch (Exception e) {
+			System.err.println(e.getMessage());
+		    //System.out.println("Unexpected Exception");
+		    //e.printStackTrace();
+		    throw new RuntimeException("Exception to terminate script");
+		}
+	}//function
+	
+	
+	
     
 	/**
 	TODO : add description (to the model)
@@ -57,7 +77,22 @@ public class GenerateMakefile  {
 		}
 	}//function
 	
-    
+	/**
+	TODO : add description (to the model)
+	**/
+	public GenerateMakefile(@IModuleArgumentName(name="program") Program program,
+@IModuleArgumentName(name="system") String system,
+@IModuleArgumentName(name="outDir") String outDir,
+@IModuleArgumentName(name="withVerification") boolean withVerification) {
+	    try {
+		    alphaz.mde.CodeGen.generateMakefile( program, system, outDir, withVerification);
+		} catch (Exception e) {
+			System.err.println(e.getMessage());
+		    //System.out.println("Unexpected Exception");
+		    //e.printStackTrace();
+		    throw new RuntimeException("Exception to terminate script");
+		}
+	}//function
 
 	/**
 	TODO : add description (to the model)

--- a/bundles/edu.csu.melange.alphaz.mde/src-gen/alphaz/mde/CodeGen.java
+++ b/bundles/edu.csu.melange.alphaz.mde/src-gen/alphaz/mde/CodeGen.java
@@ -188,7 +188,10 @@ Detailed options can be given through optional argument.
 	/**
 	Generates Makefile to compile generated code + wrapper.
 	**/
-	public static void generateMakefile(  Program program , String system , CodeGenOptions CodeGenOptions , String outDir ) {
+	public static void generateMakefile(  Program program , String system , CodeGenOptions CodeGenOptions , String outDir) {
+		generateMakefile(program, system, CodeGenOptions, outDir, false);
+	}
+	public static void generateMakefile(  Program program , String system , CodeGenOptions CodeGenOptions , String outDir , boolean withVerification) {
 		/*PROTECTED REGION ID(alphaz.mde.codegen.generateMakefile) ENABLED START*/
 		try {
 			boolean tiledWavefront = false;
@@ -232,7 +235,7 @@ Detailed options can be given through optional argument.
 				return;
 			}
 			
-			PolyIRCodeGen.generateMakefile(program.getSystem(system), outDir);
+			PolyIRCodeGen.generateMakefile(program.getSystem(system), outDir, withVerification);
 		} catch (Exception e) {
 			PolyIRCodeGen.generateMakefile(program.getSystem(system), outDir);
 		}
@@ -255,7 +258,12 @@ Detailed options can be given through optional argument.
 		generateMakefile( program, system, null , outDir);
 	}
 	
-
+	/**
+	TODO : add description (to the model)
+	**/
+	public static void generateMakefile( Program program, String system, String outDir, boolean withVerification) {
+		generateMakefile( program, system, null , outDir, withVerification);
+	}
 
 	/**
 	TODO : add description (to the model)

--- a/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/C/StatementVisitorForWriteC.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/C/StatementVisitorForWriteC.java
@@ -65,6 +65,7 @@ public class StatementVisitorForWriteC extends PolyhedralIRInheritedDepthFirstVi
 	//Input
 	protected final CodeUnit unit;
 	protected final TargetMapping targetMapping;
+	private String verifyPrefix;
 	
 	//local
 	protected ComputeReductionNumber reductionNumbers;
@@ -84,8 +85,8 @@ public class StatementVisitorForWriteC extends PolyhedralIRInheritedDepthFirstVi
 	protected StatementVisitorForWriteC(CodeUnit unit, TargetMapping mapping) {
 		this.unit = unit;
 		this.targetMapping = mapping;
+		this.verifyPrefix = unit.getSystem().getName().endsWith("_verify") ? "verify_" : "";
 	}
-	
 
 	@Override
 	public void inAffineSystem(AffineSystem a) {
@@ -172,7 +173,7 @@ public class StatementVisitorForWriteC extends PolyhedralIRInheritedDepthFirstVi
 		}
 		Statement stmt = _fact.createStatement(
 				CodeGenUtility.createStatementName(unit, 0), var.getDomain().copy(), 
-				CodeGenConstantsForC.WRITEC_EVAL_PREFIX+var.getName()+"("+
+				CodeGenConstantsForC.WRITEC_EVAL_PREFIX+this.verifyPrefix+var.getName()+"("+
 						CodeGenUtility.toStringList(evalFuncParams, ",")+")");
 		
 		// Remove time domain from the statements in the loop. So that an 
@@ -237,7 +238,10 @@ public class StatementVisitorForWriteC extends PolyhedralIRInheritedDepthFirstVi
 	
 	@Override
 	public void outStandardEquation(StandardEquation s) {
-		Function function = _fact.createFunction(CodeGenConstantsForC.WRITEC_EVAL_PREFIX+s.getVariable().getName(), s.getVariable().getType());
+		Function function = _fact.createFunction(
+				CodeGenConstantsForC.WRITEC_EVAL_PREFIX+this.verifyPrefix+s.getVariable().getName(),
+				s.getVariable().getType()
+		);
 		
 		//Add loop indices as function parameters
 		for (Variable iv : s.getVariable().getDomain().getIndices()) {

--- a/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/PolyIRCodeGen.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/PolyIRCodeGen.java
@@ -137,6 +137,9 @@ public class PolyIRCodeGen {
 	
 	//for test now
 	public static void generateMakefile(AbstractModule module, AffineSystem system, boolean omp, String outDir){
+		generateMakefile(module, system, omp, outDir, false);
+	}
+	public static void generateMakefile(AbstractModule module, AffineSystem system, boolean omp, String outDir, boolean withVerification){
 		File dir = new File(outDir);
 		if (!dir.exists() && !dir.mkdirs()) {
 			throw new RuntimeException("Failed to create output directory : " + outDir);
@@ -146,15 +149,15 @@ public class PolyIRCodeGen {
 		List<AffineSystem> systems = SystemCallAnalysis.getUsedSystems(system);
 		Map<String, String> codes;
 		if (module != null) {
-			codes = Xtend2MakefileGen.generate(module, system, systems, omp);
+			codes = Xtend2MakefileGen.generate(module, system, systems, omp, withVerification);
 		} else {
-			codes = Xtend2MakefileGen.generate(system, systems, omp);
+			codes = Xtend2MakefileGen.generate(system, systems, omp, withVerification);
 		}
 		for (String file : codes.keySet()) {
 			writeFile(dir, file, codes.get(file));
 		}
 	}
-	
+
 	public static void generateMakefile(AbstractModule module, AffineSystem system, String outDir){
 		generateMakefile(module, system, false, outDir);
 	}
@@ -163,6 +166,10 @@ public class PolyIRCodeGen {
 		generateMakefile(null, system, false, outDir);
 	}
 	
+	public static void generateMakefile(AffineSystem system, String outDir, boolean withVerification){
+		generateMakefile(null, system, false, outDir, withVerification);
+	}
+
 	public static void generateOMPMakefile(AbstractModule module, AffineSystem system, String outDir){
 		generateMakefile(module, system, true, outDir);
 	}

--- a/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/Xtend2MakefileGen.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/Xtend2MakefileGen.java
@@ -12,14 +12,22 @@ import com.google.inject.Guice;
 public class Xtend2MakefileGen {
 
 	public static Map<String, String> generate(AffineSystem system, List<AffineSystem> systems, boolean omp) {
+		return generate(system, systems, omp, false);
+	}
+
+	public static Map<String, String> generate(AffineSystem system, List<AffineSystem> systems, boolean omp, boolean withVerification) {
 		Xtend2MakefileTop instance = Guice.createInjector().getInstance(Xtend2MakefileTop.class);
 
-		return instance.generate(system, systems, omp);
+		return instance.generate(system, systems, omp, withVerification);
 	}
-	
+
 	public static Map<String, String> generate(AbstractModule module, AffineSystem system, List<AffineSystem> systems, boolean omp) {
+		return generate(module, system, systems, omp, false);
+	}
+
+	public static Map<String, String> generate(AbstractModule module, AffineSystem system, List<AffineSystem> systems, boolean omp, boolean withVerification) {
 		Xtend2MakefileTop instance = Guice.createInjector(module).getInstance(Xtend2MakefileTop.class);
 
-		return instance.generate(system, systems, omp);
+		return instance.generate(system, systems, omp, withVerification);
 	}
 }

--- a/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/make/BaseMakefile.xtend
+++ b/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/make/BaseMakefile.xtend
@@ -9,14 +9,18 @@ import java.util.LinkedList
 
 class BaseMakefile {
 	
-    def Map<String,String> generate (AffineSystem system, List<AffineSystem> systems, boolean omp)  {
+	def Map<String,String> generate (AffineSystem system, List<AffineSystem> systems, boolean omp)  {
+		generate(system, systems, omp, false)
+	}
+
+    def Map<String,String> generate (AffineSystem system, List<AffineSystem> systems, boolean omp, boolean withVerification)  {
     	val files = new TreeMap<String,String>();
     	
     	val systemNames = new LinkedList<CharSequence>();
     	for(AffineSystem sys : systems){
     		systemNames.add(sys.name);
     	}
-    	files.put("Makefile", makefile(system.name, systemNames, system.name+VERIFY_POSTFIX, omp).toString)
+    	files.put("Makefile", makefile(system.name, systemNames, system.name+VERIFY_POSTFIX, omp, withVerification).toString)
     	
 		return files    	
 	 }
@@ -66,22 +70,26 @@ class BaseMakefile {
 		return '''«objs»'''
 	}
 
-	def CharSequence makefile(CharSequence name, List<CharSequence> names, CharSequence verifyName, boolean omp) '''
+	def CharSequence makefile(CharSequence name, List<CharSequence> names, CharSequence verifyName, boolean omp) {
+		makefile(name, names, verifyName, omp, false)
+	}
+
+	def CharSequence makefile(CharSequence name, List<CharSequence> names, CharSequence verifyName, boolean omp, boolean withVerification) '''
 		CFLAGS=«IF omp»«ompflag» «ENDIF» «cflagsOptimization» «cflagsOthers» «includes»
 		LIBRARIES=«libraries»
 		CC?=«cc»
 		OBJS = «objects(names)»
-		all: plain check
+		all: plain check«IF withVerification» verify verify-rand«ENDIF»
 
 		debug: CFLAGS =-DDEBUG -g -Wall -Wextra«cflagsOthers»«includes»
 		debug: all
-				
+		
 		plain: $(OBJS)
 			$(CC) «name»-wrapper.c -o «name» $(OBJS) $(CFLAGS) $(LIBRARIES)
 		
 		check: $(OBJS)
 			$(CC) «name»-wrapper.c -o «name».check $(OBJS) $(CFLAGS) $(LIBRARIES) -D«CHECKING_FLAG»
-		
+		«IF withVerification»
 		verify: $(OBJS) «verifyName».o
 			$(CC) «name»-wrapper.c -o «name».verify $(OBJS) «verifyName».o $(CFLAGS) $(LIBRARIES) -D«VERIFY_FLAG»
 		
@@ -91,8 +99,8 @@ class BaseMakefile {
 		«makeObjs(names)»
 		«verifyName».o : «verifyName».c
 			$(CC) «verifyName».c -o «verifyName».o $(CFLAGS) $(LIBRARIES) -c
-		
+		«ENDIF»
 		clean:
-			rm -f *.o «name» «name».check «name».verify «name».verify-rand
+			rm -f *.o «name» «name».check«IF withVerification» «name».verify «name».verify-rand«ENDIF»
 	'''
 }

--- a/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/make/Xtend2MakefileTop.xtend
+++ b/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/make/Xtend2MakefileTop.xtend
@@ -9,8 +9,12 @@ class Xtend2MakefileTop {
 	
 	@Inject extension BaseMakefile extensions
 	
-    def Map<String, String> generate(AffineSystem system, List<AffineSystem> systems, boolean omp) {
-    	extensions.generate(system, systems, omp);
+	def Map<String, String> generate(AffineSystem system, List<AffineSystem> systems, boolean omp) {
+		generate(system, systems, omp, false);
+	}
+
+    def Map<String, String> generate(AffineSystem system, List<AffineSystem> systems, boolean omp, boolean withVerification) {
+		extensions.generate(system, systems, omp, withVerification);
     }
     
 }

--- a/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/make/BaseMakefile.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/make/BaseMakefile.java
@@ -11,6 +11,10 @@ import org.polymodel.polyhedralIR.polyIRCG.generator.C.CodeGenConstantsForC;
 @SuppressWarnings("all")
 public class BaseMakefile {
   public Map<String, String> generate(final AffineSystem system, final List<AffineSystem> systems, final boolean omp) {
+    return this.generate(system, systems, omp, false);
+  }
+  
+  public Map<String, String> generate(final AffineSystem system, final List<AffineSystem> systems, final boolean omp, final boolean withVerification) {
     final TreeMap<String, String> files = new TreeMap<String, String>();
     final LinkedList<CharSequence> systemNames = new LinkedList<CharSequence>();
     for (final AffineSystem sys : systems) {
@@ -19,7 +23,7 @@ public class BaseMakefile {
     String _name = system.getName();
     String _name_1 = system.getName();
     String _plus = (_name_1 + CodeGenConstantsForC.VERIFY_POSTFIX);
-    files.put("Makefile", this.makefile(_name, systemNames, _plus, omp).toString());
+    files.put("Makefile", this.makefile(_name, systemNames, _plus, omp, withVerification).toString());
     return files;
   }
   
@@ -103,6 +107,10 @@ public class BaseMakefile {
   }
   
   public CharSequence makefile(final CharSequence name, final List<CharSequence> names, final CharSequence verifyName, final boolean omp) {
+    return this.makefile(name, names, verifyName, omp, false);
+  }
+  
+  public CharSequence makefile(final CharSequence name, final List<CharSequence> names, final CharSequence verifyName, final boolean omp, final boolean withVerification) {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("CFLAGS=");
     {
@@ -135,7 +143,12 @@ public class BaseMakefile {
     _builder.append(_objects);
     _builder.newLineIfNotEmpty();
     _builder.append("all: plain check");
-    _builder.newLine();
+    {
+      if (withVerification) {
+        _builder.append(" verify verify-rand");
+      }
+    }
+    _builder.newLineIfNotEmpty();
     _builder.newLine();
     _builder.append("debug: CFLAGS =-DDEBUG -g -Wall -Wextra");
     CharSequence _cflagsOthers_1 = this.cflagsOthers();
@@ -145,7 +158,6 @@ public class BaseMakefile {
     _builder.newLineIfNotEmpty();
     _builder.append("debug: all");
     _builder.newLine();
-    _builder.append("\t\t");
     _builder.newLine();
     _builder.append("plain: $(OBJS)");
     _builder.newLine();
@@ -167,55 +179,57 @@ public class BaseMakefile {
     _builder.append(".check $(OBJS) $(CFLAGS) $(LIBRARIES) -D");
     _builder.append(CodeGenConstantsForC.CHECKING_FLAG, "\t");
     _builder.newLineIfNotEmpty();
-    _builder.newLine();
-    _builder.append("verify: $(OBJS) ");
-    _builder.append(verifyName);
-    _builder.append(".o");
-    _builder.newLineIfNotEmpty();
-    _builder.append("\t");
-    _builder.append("$(CC) ");
-    _builder.append(name, "\t");
-    _builder.append("-wrapper.c -o ");
-    _builder.append(name, "\t");
-    _builder.append(".verify $(OBJS) ");
-    _builder.append(verifyName, "\t");
-    _builder.append(".o $(CFLAGS) $(LIBRARIES) -D");
-    _builder.append(CodeGenConstantsForC.VERIFY_FLAG, "\t");
-    _builder.newLineIfNotEmpty();
-    _builder.newLine();
-    _builder.append("verify-rand: $(OBJS) ");
-    _builder.append(verifyName);
-    _builder.append(".o");
-    _builder.newLineIfNotEmpty();
-    _builder.append("\t");
-    _builder.append("$(CC) ");
-    _builder.append(name, "\t");
-    _builder.append("-wrapper.c -o ");
-    _builder.append(name, "\t");
-    _builder.append(".verify-rand $(OBJS) ");
-    _builder.append(verifyName, "\t");
-    _builder.append(".o $(CFLAGS) $(LIBRARIES) -D");
-    _builder.append(CodeGenConstantsForC.VERIFY_FLAG, "\t");
-    _builder.append(" -D");
-    _builder.append(CodeGenConstantsForC.RANDOM_FLAG, "\t");
-    _builder.newLineIfNotEmpty();
-    _builder.newLine();
-    CharSequence _makeObjs = this.makeObjs(names);
-    _builder.append(_makeObjs);
-    _builder.newLineIfNotEmpty();
-    _builder.append(verifyName);
-    _builder.append(".o : ");
-    _builder.append(verifyName);
-    _builder.append(".c");
-    _builder.newLineIfNotEmpty();
-    _builder.append("\t");
-    _builder.append("$(CC) ");
-    _builder.append(verifyName, "\t");
-    _builder.append(".c -o ");
-    _builder.append(verifyName, "\t");
-    _builder.append(".o $(CFLAGS) $(LIBRARIES) -c");
-    _builder.newLineIfNotEmpty();
-    _builder.newLine();
+    {
+      if (withVerification) {
+        _builder.append("verify: $(OBJS) ");
+        _builder.append(verifyName);
+        _builder.append(".o");
+        _builder.newLineIfNotEmpty();
+        _builder.append("\t");
+        _builder.append("$(CC) ");
+        _builder.append(name, "\t");
+        _builder.append("-wrapper.c -o ");
+        _builder.append(name, "\t");
+        _builder.append(".verify $(OBJS) ");
+        _builder.append(verifyName, "\t");
+        _builder.append(".o $(CFLAGS) $(LIBRARIES) -D");
+        _builder.append(CodeGenConstantsForC.VERIFY_FLAG, "\t");
+        _builder.newLineIfNotEmpty();
+        _builder.newLine();
+        _builder.append("verify-rand: $(OBJS) ");
+        _builder.append(verifyName);
+        _builder.append(".o");
+        _builder.newLineIfNotEmpty();
+        _builder.append("\t");
+        _builder.append("$(CC) ");
+        _builder.append(name, "\t");
+        _builder.append("-wrapper.c -o ");
+        _builder.append(name, "\t");
+        _builder.append(".verify-rand $(OBJS) ");
+        _builder.append(verifyName, "\t");
+        _builder.append(".o $(CFLAGS) $(LIBRARIES) -D");
+        _builder.append(CodeGenConstantsForC.VERIFY_FLAG, "\t");
+        _builder.append(" -D");
+        _builder.append(CodeGenConstantsForC.RANDOM_FLAG, "\t");
+        _builder.newLineIfNotEmpty();
+        _builder.newLine();
+        CharSequence _makeObjs = this.makeObjs(names);
+        _builder.append(_makeObjs);
+        _builder.newLineIfNotEmpty();
+        _builder.append(verifyName);
+        _builder.append(".o : ");
+        _builder.append(verifyName);
+        _builder.append(".c");
+        _builder.newLineIfNotEmpty();
+        _builder.append("\t");
+        _builder.append("$(CC) ");
+        _builder.append(verifyName, "\t");
+        _builder.append(".c -o ");
+        _builder.append(verifyName, "\t");
+        _builder.append(".o $(CFLAGS) $(LIBRARIES) -c");
+        _builder.newLineIfNotEmpty();
+      }
+    }
     _builder.append("clean:");
     _builder.newLine();
     _builder.append("\t");
@@ -223,11 +237,16 @@ public class BaseMakefile {
     _builder.append(name, "\t");
     _builder.append(" ");
     _builder.append(name, "\t");
-    _builder.append(".check ");
-    _builder.append(name, "\t");
-    _builder.append(".verify ");
-    _builder.append(name, "\t");
-    _builder.append(".verify-rand");
+    _builder.append(".check");
+    {
+      if (withVerification) {
+        _builder.append(" ");
+        _builder.append(name, "\t");
+        _builder.append(".verify ");
+        _builder.append(name, "\t");
+        _builder.append(".verify-rand");
+      }
+    }
     _builder.newLineIfNotEmpty();
     return _builder;
   }

--- a/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/make/Xtend2MakefileTop.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/make/Xtend2MakefileTop.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.polymodel.polyhedralIR.AffineSystem;
-import org.polymodel.polyhedralIR.codegen.xtend2.make.BaseMakefile;
 
 @SuppressWarnings("all")
 public class Xtend2MakefileTop {
@@ -14,6 +13,10 @@ public class Xtend2MakefileTop {
   private BaseMakefile extensions;
   
   public Map<String, String> generate(final AffineSystem system, final List<AffineSystem> systems, final boolean omp) {
-    return this.extensions.generate(system, systems, omp);
+    return this.generate(system, systems, omp, false);
+  }
+  
+  public Map<String, String> generate(final AffineSystem system, final List<AffineSystem> systems, final boolean omp, final boolean withVerification) {
+    return this.extensions.generate(system, systems, omp, withVerification);
   }
 }


### PR DESCRIPTION
Previously `generateVerificationCode` and `generateWriteC` did not work together because they both use the same `eval_` prefix in the generated code. Now the verification code uses the prefix `eval_verify_` instead.

Previously `generateMakefile` would produce a Makefile that looked something like this:
```
...
all: plain check
...
verify: ...

verify-rand: ...
```
and when you run `make`, only the plain and check targets are built. You have to manually run `make verify` to have it also build the verification code (if it was generated). But if you haven't generated the verification code, and try to run `make verify` then compilation will fail (obviously) because there are no C files for the verification code.

I don't think it makes sense to put verification targets in the generated Makefile if `generateVerificationCode` has not also been run. However, there is not a good way to determine if `generateVerificationCode` has been run because the system does not really keep track of state during the execution of command scripts. Instead, now this can be controlled with an additional parameter to the `generateMakefile` command.

There are two new commands (with the following signatures):
```
GenerateMakefile(Program program, String system, String outDir, boolean withVerification)
GenerateMakefile(Program program, String system, CodeGenOptions CodeGenOptions, String outDir, boolean withVerification)
```
The default behavior is to generate ***no*** verification targets/commands in the Makefile if withVerification is not specified.

## Default behavior (no verification targets)

This command...
```
generateMakefile(prog, system, out);
```
will generate a Makefile like this:
```
CFLAGS= -O3  -std=c99  -I/usr/include/malloc/
LIBRARIES=-lm
CC?=gcc
OBJS = matmult.o 
all: plain check

debug: CFLAGS =-DDEBUG -g -Wall -Wextra -std=c99 -I/usr/include/malloc/
debug: all

plain: $(OBJS)
	$(CC) matmult-wrapper.c -o matmult $(OBJS) $(CFLAGS) $(LIBRARIES)

check: $(OBJS)
	$(CC) matmult-wrapper.c -o matmult.check $(OBJS) $(CFLAGS) $(LIBRARIES) -DCHECKING
clean:
	rm -f *.o matmult matmult.check
```

## How to generate verification targets

This command passing `withVerification` as true...
```
generateMakefile(prog, system, out, true);
```
will generate a Makefile like this:
```
CFLAGS= -O3  -std=c99  -I/usr/include/malloc/
LIBRARIES=-lm
CC?=gcc
OBJS = matmult.o 
all: plain check verify verify-rand

debug: CFLAGS =-DDEBUG -g -Wall -Wextra -std=c99 -I/usr/include/malloc/
debug: all

plain: $(OBJS)
	$(CC) matmult-wrapper.c -o matmult $(OBJS) $(CFLAGS) $(LIBRARIES)

check: $(OBJS)
	$(CC) matmult-wrapper.c -o matmult.check $(OBJS) $(CFLAGS) $(LIBRARIES) -DCHECKING
verify: $(OBJS) matmult_verify.o
	$(CC) matmult-wrapper.c -o matmult.verify $(OBJS) matmult_verify.o $(CFLAGS) $(LIBRARIES) -DVERIFY

verify-rand: $(OBJS) matmult_verify.o
	$(CC) matmult-wrapper.c -o matmult.verify-rand $(OBJS) matmult_verify.o $(CFLAGS) $(LIBRARIES) -DVERIFY -DRANDOM

matmult.o : matmult.c
	$(CC) matmult.c -o matmult.o $(CFLAGS) $(LIBRARIES) -c

matmult_verify.o : matmult_verify.c
	$(CC) matmult_verify.c -o matmult_verify.o $(CFLAGS) $(LIBRARIES) -c
clean:
	rm -f *.o matmult matmult.check matmult.verify matmult.verify-rand
```