### PR TITLE
fix: add object targets Makefile

### DIFF
--- a/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/make/BaseMakefile.xtend
+++ b/bundles/org.polymodel.polyhedralIR.codegen/templates/org/polymodel/polyhedralIR/codegen/xtend2/make/BaseMakefile.xtend
@@ -74,7 +74,11 @@ class BaseMakefile {
 		makefile(name, names, verifyName, omp, false)
 	}
 
-	def CharSequence makefile(CharSequence name, List<CharSequence> names, CharSequence verifyName, boolean omp, boolean withVerification) '''
+	def CharSequence makefile(CharSequence name, List<CharSequence> names, CharSequence verifyName, boolean omp, boolean withVerification) {
+		val x = makeObjs(names)
+		println("asdf")
+	
+	'''
 		CFLAGS=«IF omp»«ompflag» «ENDIF» «cflagsOptimization» «cflagsOthers» «includes»
 		LIBRARIES=«libraries»
 		CC?=«cc»
@@ -89,6 +93,7 @@ class BaseMakefile {
 		
 		check: $(OBJS)
 			$(CC) «name»-wrapper.c -o «name».check $(OBJS) $(CFLAGS) $(LIBRARIES) -D«CHECKING_FLAG»
+		
 		«IF withVerification»
 		verify: $(OBJS) «verifyName».o
 			$(CC) «name»-wrapper.c -o «name».verify $(OBJS) «verifyName».o $(CFLAGS) $(LIBRARIES) -D«VERIFY_FLAG»
@@ -96,11 +101,16 @@ class BaseMakefile {
 		verify-rand: $(OBJS) «verifyName».o
 			$(CC) «name»-wrapper.c -o «name».verify-rand $(OBJS) «verifyName».o $(CFLAGS) $(LIBRARIES) -D«VERIFY_FLAG» -D«RANDOM_FLAG»
 		
+		«ENDIF»
 		«makeObjs(names)»
+		«IF withVerification»
 		«verifyName».o : «verifyName».c
 			$(CC) «verifyName».c -o «verifyName».o $(CFLAGS) $(LIBRARIES) -c
+		
 		«ENDIF»
 		clean:
 			rm -f *.o «name» «name».check«IF withVerification» «name».verify «name».verify-rand«ENDIF»
 	'''
+	}
+	
 }

--- a/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/make/BaseMakefile.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/xtend-gen/org/polymodel/polyhedralIR/codegen/xtend2/make/BaseMakefile.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.xbase.lib.InputOutput;
 import org.polymodel.polyhedralIR.AffineSystem;
 import org.polymodel.polyhedralIR.polyIRCG.generator.C.CodeGenConstantsForC;
 
@@ -111,143 +112,155 @@ public class BaseMakefile {
   }
   
   public CharSequence makefile(final CharSequence name, final List<CharSequence> names, final CharSequence verifyName, final boolean omp, final boolean withVerification) {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("CFLAGS=");
+    CharSequence _xblockexpression = null;
     {
-      if (omp) {
-        CharSequence _ompflag = this.ompflag();
-        _builder.append(_ompflag);
-        _builder.append(" ");
+      final CharSequence x = this.makeObjs(names);
+      InputOutput.<String>println("asdf");
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("CFLAGS=");
+      {
+        if (omp) {
+          CharSequence _ompflag = this.ompflag();
+          _builder.append(_ompflag);
+          _builder.append(" ");
+        }
       }
-    }
-    _builder.append(" ");
-    CharSequence _cflagsOptimization = this.cflagsOptimization();
-    _builder.append(_cflagsOptimization);
-    _builder.append(" ");
-    CharSequence _cflagsOthers = this.cflagsOthers();
-    _builder.append(_cflagsOthers);
-    _builder.append(" ");
-    CharSequence _includes = this.includes();
-    _builder.append(_includes);
-    _builder.newLineIfNotEmpty();
-    _builder.append("LIBRARIES=");
-    CharSequence _libraries = this.libraries();
-    _builder.append(_libraries);
-    _builder.newLineIfNotEmpty();
-    _builder.append("CC?=");
-    CharSequence _cc = this.cc();
-    _builder.append(_cc);
-    _builder.newLineIfNotEmpty();
-    _builder.append("OBJS = ");
-    CharSequence _objects = this.objects(names);
-    _builder.append(_objects);
-    _builder.newLineIfNotEmpty();
-    _builder.append("all: plain check");
-    {
-      if (withVerification) {
-        _builder.append(" verify verify-rand");
+      _builder.append(" ");
+      CharSequence _cflagsOptimization = this.cflagsOptimization();
+      _builder.append(_cflagsOptimization);
+      _builder.append(" ");
+      CharSequence _cflagsOthers = this.cflagsOthers();
+      _builder.append(_cflagsOthers);
+      _builder.append(" ");
+      CharSequence _includes = this.includes();
+      _builder.append(_includes);
+      _builder.newLineIfNotEmpty();
+      _builder.append("LIBRARIES=");
+      CharSequence _libraries = this.libraries();
+      _builder.append(_libraries);
+      _builder.newLineIfNotEmpty();
+      _builder.append("CC?=");
+      CharSequence _cc = this.cc();
+      _builder.append(_cc);
+      _builder.newLineIfNotEmpty();
+      _builder.append("OBJS = ");
+      CharSequence _objects = this.objects(names);
+      _builder.append(_objects);
+      _builder.newLineIfNotEmpty();
+      _builder.append("all: plain check");
+      {
+        if (withVerification) {
+          _builder.append(" verify verify-rand");
+        }
       }
-    }
-    _builder.newLineIfNotEmpty();
-    _builder.newLine();
-    _builder.append("debug: CFLAGS =-DDEBUG -g -Wall -Wextra");
-    CharSequence _cflagsOthers_1 = this.cflagsOthers();
-    _builder.append(_cflagsOthers_1);
-    CharSequence _includes_1 = this.includes();
-    _builder.append(_includes_1);
-    _builder.newLineIfNotEmpty();
-    _builder.append("debug: all");
-    _builder.newLine();
-    _builder.newLine();
-    _builder.append("plain: $(OBJS)");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("$(CC) ");
-    _builder.append(name, "\t");
-    _builder.append("-wrapper.c -o ");
-    _builder.append(name, "\t");
-    _builder.append(" $(OBJS) $(CFLAGS) $(LIBRARIES)");
-    _builder.newLineIfNotEmpty();
-    _builder.newLine();
-    _builder.append("check: $(OBJS)");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("$(CC) ");
-    _builder.append(name, "\t");
-    _builder.append("-wrapper.c -o ");
-    _builder.append(name, "\t");
-    _builder.append(".check $(OBJS) $(CFLAGS) $(LIBRARIES) -D");
-    _builder.append(CodeGenConstantsForC.CHECKING_FLAG, "\t");
-    _builder.newLineIfNotEmpty();
-    {
-      if (withVerification) {
-        _builder.append("verify: $(OBJS) ");
-        _builder.append(verifyName);
-        _builder.append(".o");
-        _builder.newLineIfNotEmpty();
-        _builder.append("\t");
-        _builder.append("$(CC) ");
-        _builder.append(name, "\t");
-        _builder.append("-wrapper.c -o ");
-        _builder.append(name, "\t");
-        _builder.append(".verify $(OBJS) ");
-        _builder.append(verifyName, "\t");
-        _builder.append(".o $(CFLAGS) $(LIBRARIES) -D");
-        _builder.append(CodeGenConstantsForC.VERIFY_FLAG, "\t");
-        _builder.newLineIfNotEmpty();
-        _builder.newLine();
-        _builder.append("verify-rand: $(OBJS) ");
-        _builder.append(verifyName);
-        _builder.append(".o");
-        _builder.newLineIfNotEmpty();
-        _builder.append("\t");
-        _builder.append("$(CC) ");
-        _builder.append(name, "\t");
-        _builder.append("-wrapper.c -o ");
-        _builder.append(name, "\t");
-        _builder.append(".verify-rand $(OBJS) ");
-        _builder.append(verifyName, "\t");
-        _builder.append(".o $(CFLAGS) $(LIBRARIES) -D");
-        _builder.append(CodeGenConstantsForC.VERIFY_FLAG, "\t");
-        _builder.append(" -D");
-        _builder.append(CodeGenConstantsForC.RANDOM_FLAG, "\t");
-        _builder.newLineIfNotEmpty();
-        _builder.newLine();
-        CharSequence _makeObjs = this.makeObjs(names);
-        _builder.append(_makeObjs);
-        _builder.newLineIfNotEmpty();
-        _builder.append(verifyName);
-        _builder.append(".o : ");
-        _builder.append(verifyName);
-        _builder.append(".c");
-        _builder.newLineIfNotEmpty();
-        _builder.append("\t");
-        _builder.append("$(CC) ");
-        _builder.append(verifyName, "\t");
-        _builder.append(".c -o ");
-        _builder.append(verifyName, "\t");
-        _builder.append(".o $(CFLAGS) $(LIBRARIES) -c");
-        _builder.newLineIfNotEmpty();
+      _builder.newLineIfNotEmpty();
+      _builder.newLine();
+      _builder.append("debug: CFLAGS =-DDEBUG -g -Wall -Wextra");
+      CharSequence _cflagsOthers_1 = this.cflagsOthers();
+      _builder.append(_cflagsOthers_1);
+      CharSequence _includes_1 = this.includes();
+      _builder.append(_includes_1);
+      _builder.newLineIfNotEmpty();
+      _builder.append("debug: all");
+      _builder.newLine();
+      _builder.newLine();
+      _builder.append("plain: $(OBJS)");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("$(CC) ");
+      _builder.append(name, "\t");
+      _builder.append("-wrapper.c -o ");
+      _builder.append(name, "\t");
+      _builder.append(" $(OBJS) $(CFLAGS) $(LIBRARIES)");
+      _builder.newLineIfNotEmpty();
+      _builder.newLine();
+      _builder.append("check: $(OBJS)");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("$(CC) ");
+      _builder.append(name, "\t");
+      _builder.append("-wrapper.c -o ");
+      _builder.append(name, "\t");
+      _builder.append(".check $(OBJS) $(CFLAGS) $(LIBRARIES) -D");
+      _builder.append(CodeGenConstantsForC.CHECKING_FLAG, "\t");
+      _builder.newLineIfNotEmpty();
+      _builder.newLine();
+      {
+        if (withVerification) {
+          _builder.append("verify: $(OBJS) ");
+          _builder.append(verifyName);
+          _builder.append(".o");
+          _builder.newLineIfNotEmpty();
+          _builder.append("\t");
+          _builder.append("$(CC) ");
+          _builder.append(name, "\t");
+          _builder.append("-wrapper.c -o ");
+          _builder.append(name, "\t");
+          _builder.append(".verify $(OBJS) ");
+          _builder.append(verifyName, "\t");
+          _builder.append(".o $(CFLAGS) $(LIBRARIES) -D");
+          _builder.append(CodeGenConstantsForC.VERIFY_FLAG, "\t");
+          _builder.newLineIfNotEmpty();
+          _builder.newLine();
+          _builder.append("verify-rand: $(OBJS) ");
+          _builder.append(verifyName);
+          _builder.append(".o");
+          _builder.newLineIfNotEmpty();
+          _builder.append("\t");
+          _builder.append("$(CC) ");
+          _builder.append(name, "\t");
+          _builder.append("-wrapper.c -o ");
+          _builder.append(name, "\t");
+          _builder.append(".verify-rand $(OBJS) ");
+          _builder.append(verifyName, "\t");
+          _builder.append(".o $(CFLAGS) $(LIBRARIES) -D");
+          _builder.append(CodeGenConstantsForC.VERIFY_FLAG, "\t");
+          _builder.append(" -D");
+          _builder.append(CodeGenConstantsForC.RANDOM_FLAG, "\t");
+          _builder.newLineIfNotEmpty();
+          _builder.newLine();
+        }
       }
-    }
-    _builder.append("clean:");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("rm -f *.o ");
-    _builder.append(name, "\t");
-    _builder.append(" ");
-    _builder.append(name, "\t");
-    _builder.append(".check");
-    {
-      if (withVerification) {
-        _builder.append(" ");
-        _builder.append(name, "\t");
-        _builder.append(".verify ");
-        _builder.append(name, "\t");
-        _builder.append(".verify-rand");
+      CharSequence _makeObjs = this.makeObjs(names);
+      _builder.append(_makeObjs);
+      _builder.newLineIfNotEmpty();
+      {
+        if (withVerification) {
+          _builder.append(verifyName);
+          _builder.append(".o : ");
+          _builder.append(verifyName);
+          _builder.append(".c");
+          _builder.newLineIfNotEmpty();
+          _builder.append("\t");
+          _builder.append("$(CC) ");
+          _builder.append(verifyName, "\t");
+          _builder.append(".c -o ");
+          _builder.append(verifyName, "\t");
+          _builder.append(".o $(CFLAGS) $(LIBRARIES) -c");
+          _builder.newLineIfNotEmpty();
+          _builder.newLine();
+        }
       }
+      _builder.append("clean:");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("rm -f *.o ");
+      _builder.append(name, "\t");
+      _builder.append(" ");
+      _builder.append(name, "\t");
+      _builder.append(".check");
+      {
+        if (withVerification) {
+          _builder.append(" ");
+          _builder.append(name, "\t");
+          _builder.append(".verify ");
+          _builder.append(name, "\t");
+          _builder.append(".verify-rand");
+        }
+      }
+      _builder.newLineIfNotEmpty();
+      _xblockexpression = _builder;
     }
-    _builder.newLineIfNotEmpty();
-    return _builder;
+    return _xblockexpression;
   }
 }


### PR DESCRIPTION
I missed this in PR #11. Now if `withVerification` is not passed, the original object targets are still correctly generated in the Makefile.