### PR TITLE
fix: also add 'verify_' prefix in verification codegen using reductions

### DIFF
--- a/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/C/ExpressionPrinterForWriteC.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/C/ExpressionPrinterForWriteC.java
@@ -31,6 +31,8 @@ import org.polymodel.polyhedralIR.targetMapping.TargetMapping;
  */
 public class ExpressionPrinterForWriteC extends ExpressionPrinterForC {
 	
+	public static String verifyPrefix = "";
+
 	protected ExpressionPrinterForWriteC(TargetMapping tm) {
 		super(tm, false);
 	}
@@ -83,12 +85,12 @@ public class ExpressionPrinterForWriteC extends ExpressionPrinterForC {
 		if (ms.getDomain().getNIndices() == 0) {
 			//scalars are dereferenced in the original 
 			original = "\\*"+ms.getName();
-			replace = String.format("%s%s\\(%s)", CodeGenConstantsForC.WRITEC_EVAL_PREFIX, ms.getName(), CodeGenUtility.toStringList(names, ","));
+			replace = String.format("%s%s%s\\(%s)", CodeGenConstantsForC.WRITEC_EVAL_PREFIX, verifyPrefix, ms.getName(), CodeGenUtility.toStringList(names, ","));
 		} else {
 			//Add prefix to make it evaluation function
 			original = ms.getName()+"\\(";
 			//variables have other indices following
-			replace = String.format("%s%s\\(%s,", CodeGenConstantsForC.WRITEC_EVAL_PREFIX, ms.getName(), CodeGenUtility.toStringList(names, ","));
+			replace = String.format("%s%s%s\\(%s,", CodeGenConstantsForC.WRITEC_EVAL_PREFIX, verifyPrefix, ms.getName(), CodeGenUtility.toStringList(names, ","));
 		}
 		
 		

--- a/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/C/StatementVisitorForWriteC.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/C/StatementVisitorForWriteC.java
@@ -85,7 +85,13 @@ public class StatementVisitorForWriteC extends PolyhedralIRInheritedDepthFirstVi
 	protected StatementVisitorForWriteC(CodeUnit unit, TargetMapping mapping) {
 		this.unit = unit;
 		this.targetMapping = mapping;
-		this.verifyPrefix = unit.getSystem().getName().endsWith("_verify") ? "verify_" : "";
+		if (unit.getSystem().getName().endsWith("_verify")) {
+			this.verifyPrefix = "verify_";
+			ExpressionPrinterForWriteC.verifyPrefix = "verify_";
+		} else {
+			this.verifyPrefix = "";
+			ExpressionPrinterForWriteC.verifyPrefix = "";
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This complements PR #11. I missed adding the `verify_` prefix in the ExpressionPrinter as well, which gets called by the StatementVisitor when there are reductions.

Now, `eval_` prefixes correctly include the `verify_` prefix as well inside the reduction functions.