### PR TITLE
fix: correctly generate Makefile verify targets when setParallel is used

### DIFF
--- a/bundles/edu.csu.melange.alphaz.mde/src-gen/alphaz/mde/CodeGen.java
+++ b/bundles/edu.csu.melange.alphaz.mde/src-gen/alphaz/mde/CodeGen.java
@@ -219,25 +219,25 @@ Detailed options can be given through optional argument.
 			}
 			
 			if(tiledVec && tiledWavefront){
-				PolyIRCodeGen.generateOMPMakefile(new SIMDMakefileModule(), program.getSystem(system), outDir);
+				PolyIRCodeGen.generateOMPMakefile(new SIMDMakefileModule(), program.getSystem(system), outDir, withVerification);
 				return;
 			}else if(tiledVec && !tiledWavefront){
-				PolyIRCodeGen.generateMakefile(new SIMDMakefileModule(), program.getSystem(system), outDir);
+				PolyIRCodeGen.generateMakefile(new SIMDMakefileModule(), program.getSystem(system), outDir, withVerification);
 				return;
 			}else if(!tiledVec && tiledWavefront){
-				PolyIRCodeGen.generateOMPMakefile(program.getSystem(system), outDir);
+				PolyIRCodeGen.generateOMPMakefile(program.getSystem(system), outDir, withVerification);
 				return;
 			}
 			
 			if(program.getSystem(system).getTargetMapping().getSpaceTimeLevels().get(0).getParallelizationSpecifications().size() > 0){
-				PolyIRCodeGen.generateOMPMakefile(program.getSystem(system), outDir);
+				PolyIRCodeGen.generateOMPMakefile(program.getSystem(system), outDir, withVerification);
 				//PolyIRCodeGen.generateMakefile(new OpenMPMakefileModule(), program.getSystem(system), true, outDir);
 				return;
 			}
 			
 			PolyIRCodeGen.generateMakefile(program.getSystem(system), outDir, withVerification);
 		} catch (Exception e) {
-			PolyIRCodeGen.generateMakefile(program.getSystem(system), outDir);
+			PolyIRCodeGen.generateMakefile(program.getSystem(system), outDir, withVerification);
 		}
 		/*PROTECTED REGION END*/
 	}

--- a/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/PolyIRCodeGen.java
+++ b/bundles/org.polymodel.polyhedralIR.codegen/src/org/polymodel/polyhedralIR/polyIRCG/generator/PolyIRCodeGen.java
@@ -159,22 +159,30 @@ public class PolyIRCodeGen {
 	}
 
 	public static void generateMakefile(AbstractModule module, AffineSystem system, String outDir){
-		generateMakefile(module, system, false, outDir);
+		generateMakefile(module, system, outDir, false);
+	}
+	public static void generateMakefile(AbstractModule module, AffineSystem system, String outDir, boolean withVerification){
+		generateMakefile(module, system, false, outDir, withVerification);
 	}
 	
 	public static void generateMakefile(AffineSystem system, String outDir){
 		generateMakefile(null, system, false, outDir);
 	}
-	
 	public static void generateMakefile(AffineSystem system, String outDir, boolean withVerification){
 		generateMakefile(null, system, false, outDir, withVerification);
 	}
 
 	public static void generateOMPMakefile(AbstractModule module, AffineSystem system, String outDir){
-		generateMakefile(module, system, true, outDir);
+		generateOMPMakefile(module, system, outDir, false);
+	}
+	public static void generateOMPMakefile(AbstractModule module, AffineSystem system, String outDir, boolean withVerification){
+		generateMakefile(module, system, true, outDir, withVerification);
 	}
 	
 	public static void generateOMPMakefile(AffineSystem system, String outDir){
-		generateMakefile(null, system, true, outDir);
+		generateOMPMakefile(system, outDir, false);
+	}
+	public static void generateOMPMakefile(AffineSystem system, String outDir, boolean withVerification){
+		generateMakefile(null, system, true, outDir, withVerification);
 	}
 }


### PR DESCRIPTION
Fixes issue #19. The verification targets aren't always generated in the Makefile when they should be if `setParallel` is used. This is because if setParallel is used, the codegen calls into a different function `generateOMPMakefile`, and the verification flag was not passed when it should have been.