### PR TITLE
Add existential clauses when needed

### DIFF
--- a/bundles/org.polymodel.algebra/META-INF/MANIFEST.MF
+++ b/bundles/org.polymodel.algebra/META-INF/MANIFEST.MF
@@ -33,5 +33,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.xbase.lib,
  tom.mapping;bundle-version="1.0.0",
  fr.irisa.cairn.eclipse.tom,
- fr.irisa.cairn.tools;bundle-version="1.0.0"
+ fr.irisa.cairn.tools;bundle-version="1.0.0",
+ org.polymodel;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.polymodel.algebra/src/org/polymodel/algebra/prettyprinter/algebra/ISLPrettyPrinter.java
+++ b/bundles/org.polymodel.algebra/src/org/polymodel/algebra/prettyprinter/algebra/ISLPrettyPrinter.java
@@ -1,5 +1,9 @@
 package org.polymodel.algebra.prettyprinter.algebra;
 
+import java.util.ArrayList;
+
+import org.eclipse.emf.common.util.EList;
+import org.polymodel.ExistentialVariable;
 import org.polymodel.algebra.ComparisonOperator;
 import org.polymodel.algebra.CompositeIntExpression;
 import org.polymodel.algebra.CompositeOperator;
@@ -73,7 +77,21 @@ public class ISLPrettyPrinter extends AbstractPrettyPrinter {
 	}
 
 	public void visitAffineExpression(AffineExpression a) {
-		separateAffine(a.getTerms());
+		EList<AffineTerm> affineTerms = a.getTerms();
+		preprendExistential(affineTerms);
+		separateAffine(affineTerms);
+	}
+	
+	public void preprendExistential(EList<AffineTerm> terms) {
+		ArrayList<String> existentials = new ArrayList<>();
+		for (AffineTerm term : terms) {
+			if (term.getVariable() instanceof ExistentialVariable) {
+				existentials.add(term.getVariable().getName());
+			}
+		}
+		if (existentials.size() == 0)
+			return;
+		buffer.append("exists " + String.join(", ", existentials) + " : ");
 	}
 
 	public void visitAffineTerm(AffineTerm affineTerm) {


### PR DESCRIPTION
Fixes issue #23.

Now the org.polymodel.algebra ISL prettyprinter correctly adds existential clauses when needed.