### PR TITLE
PrintAST now emits reduction operator info

### DIFF
--- a/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/util/PrintAST.java
+++ b/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/util/PrintAST.java
@@ -19,6 +19,7 @@ import org.polymodel.polyhedralIR.expression.BinaryExpression;
 import org.polymodel.polyhedralIR.expression.ConstantExpression;
 import org.polymodel.polyhedralIR.expression.ExternalFunctionCall;
 import org.polymodel.polyhedralIR.expression.MultiArgExpression;
+import org.polymodel.polyhedralIR.expression.ReduceExpression;
 import org.polymodel.polyhedralIR.expression.RestrictExpression;
 import org.polymodel.polyhedralIR.expression.UnaryExpression;
 import org.polymodel.polyhedralIR.expression.VariableExpression;
@@ -284,5 +285,11 @@ public class PrintAST extends PolyhedralIRInheritedDepthFirstVisitorImpl {
 		} else {
 			printStr("+-- ", m.getOperator().toString());
 		}
+	}
+
+	@Override
+	public void inReduceExpression(ReduceExpression r) {
+		inExpression(r);
+		printStr("+-- ", r.getOP().toString());
 	}
 }


### PR DESCRIPTION
Updates the PrintAST visitor to also display operator info for reductions. Resolves issue #26.

For example, take this program:
```
affine info_loss1 {|}
input
output
	float Y {i|0<i};
let
	Y[i] = reduce(+, (i,j -> i), {|0<j<i} : Y[j]);
.
```

Before, calling PrintAST displayed:
```
...
   |   |   |+-- Y
   |   |   |_ReduceExpression
   |   |   |   |+--expression--{i|i>=2}
   |   |   |   |+--context--{i|i>=2}
   |   |   |   |nodeId = (0,0,0)
   |   |   |   |+-- (i,j->i)
   |   |   |   |_RestrictExpression
   |   |   |   |   |+--expression--{i,j|j>=1 && i>=j+1}
...
```

Now, calling PrintAST displays:
```
...
   |   |   |+-- Y
   |   |   |_ReduceExpression
   |   |   |   |+--expression--{i|i>=2}
   |   |   |   |+--context--{i|i>=2}
   |   |   |   |nodeId = (0,0,0)
   |   |   |   |+-- ADD
   |   |   |   |+-- (i,j->i)
   |   |   |   |_RestrictExpression
   |   |   |   |   |+--expression--{i,j|j>=1 && i>=j+1}
...
```