### PR TITLE
NormalizeReduction should not fail if reduction is already normalized

### DIFF
--- a/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/transformation/reduction/NormalizeReduction.java
+++ b/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/transformation/reduction/NormalizeReduction.java
@@ -97,7 +97,7 @@ public class NormalizeReduction {
 	public static StandardEquation apply(ReduceExpression reduce, String varName) {
 		//base check
 		if (reduce.eContainer() instanceof StandardEquation) {
-			throw new RuntimeException("This reduction is already normalized.");
+			return (StandardEquation)reduce.eContainer();
 		}
 		AffineSystem system;
 		if (reduce.getContainerEquation() instanceof StandardEquation)


### PR DESCRIPTION
Addresses issue #27. NormalizeReduction throws a runtime error if the reduction “trying to be normalized” is already in normal form. For example, NormalizeReduction fails on the following program:
```
affine info_loss1 {|}
input
output
	float Y {i|0<i};
let
	Y[i] = reduce(+, (i,j -> i), {|0<j<i} : Y[j]);
.
```

Now, NormalizeReduction just leaves the expression as is, and doesn’t throw an exception.