### PR TITLE
temporary workaround dealing with memory spaces

### DIFF
--- a/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/targetMapping/impl/MemorySpaceImpl.java
+++ b/bundles/org.polymodel.polyhedralIR/src/org/polymodel/polyhedralIR/targetMapping/impl/MemorySpaceImpl.java
@@ -179,9 +179,9 @@ public class MemorySpaceImpl extends EObjectImpl implements MemorySpace {
 
 		for (MemoryMap mmap : getMemoryMaps()) {
 			// we only want the domain of memory map for this variable
-			if (!name.equals(mmap.getVariable().getName())) {
-				continue;
-			}
+//			if (!name.equals(mmap.getVariable().getName())) {
+//				continue;
+//			}
 			AffineFunction inv;
 			try {
 				//inv = tm.getSpaceTimeMap(map.getVariable()).getMapping().inverse();


### PR DESCRIPTION
Running the AlphaZ scheduled codegen tutorial currently fails because the call to setMemoryMap:
```
setMemoryMap(program, system, "temp_C", "inner_product",  "(i,j,k->i,j)");
```
results in an issue during the 

This is **temporary** workaround and not a clean fix. But this enables the schedule codegen tutorial (for matrix product) to run successfully. Tracking the long term clean fix in Issue #35.